### PR TITLE
Fix for syncing just one locale in a consistent way, also catch a common user error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-alpha.2
+
+Bug fix for the case where a single locale is synced with `--workflow-locale` to ensure committing is possible afterwards, and a check for a common user error at startup.
+
 ## 1.0.0-alpha
 
 Initial release.

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ module.exports = {
         const path = self.apos.launder.string(req.query.path);
         const disabled = self.apos.launder.boolean(req.query.disabled);
         if (!path.length) {
-          throw self.apos.error('invalid');
+          throw self.apos.utils.error('invalid');
         }
         if (!disabled) {
           let url = self.apos.attachments.uploadfs.getUrl() + path;

--- a/index.js
+++ b/index.js
@@ -246,6 +246,9 @@ module.exports = {
     });
 
     self.syncFrom = async (env, options) => {
+      if (env.url.endsWith('/')) {
+        throw 'URL for environment must not end with /, should be a base URL for the site';
+      }
       const updatePermissions = util.promisify(self.apos.attachments.updatePermissions);
       let ended = false;
       if (!options.type) {
@@ -367,6 +370,32 @@ module.exports = {
                     );
                   } else {
                     await collection.insertOne(value.doc);
+                  }
+                  // This is A2, so when only one locale is synced
+                  // we must always match draft with live or vice versa
+                  if (query.locale && value.doc.workflowGuid) {
+                    const isDraft = query.locale.includes('-draft');
+                    const peerLocale = query.locale.includes('-draft') ? query.locale.replace('-draft', '') : (query.locale + '-draft');
+                    const existing = await collections.findOne({
+                      workflowGuid: value.doc.workflowGuid,
+                      workflowLocale: peerLocale
+                    });
+                    if (existing) {
+                      await collections.replaceOne({
+                        workflowGuid: value.doc.workflowGuid,
+                        workflowLocale: peerLocale
+                      }, {
+                        ...value.doc,
+                        workflowLocale: value.doc.workflowLocale,
+                        _id: existing._id
+                      });
+                    } else {
+                      await collections.insertOne({
+                        ...value.doc,
+                        workflowLocale: value.doc.workflowLocale,
+                        _id: self.apos.utils.generateId()
+                      });
+                    }
                   }
                 } catch (e) {
                   if ((collection.collectionName === 'aposDocs') && self.apos.docs.isUniqueError(e)) {

--- a/index.js
+++ b/index.js
@@ -375,7 +375,7 @@ module.exports = {
                   // we must always match draft with live or vice versa
                   if (query.locale && value.doc.workflowGuid) {
                     const isDraft = query.locale.includes('-draft');
-                    const peerLocale = query.locale.includes('-draft') ? query.locale.replace('-draft', '') : (query.locale + '-draft');
+                    const peerLocale = isDraft ? query.locale.replace('-draft', '') : (query.locale + '-draft');
                     const existing = await collections.findOne({
                       workflowGuid: value.doc.workflowGuid,
                       workflowLocale: peerLocale
@@ -386,14 +386,14 @@ module.exports = {
                         workflowLocale: peerLocale
                       }, {
                         ...value.doc,
-                        workflowLocale: value.doc.workflowLocale,
-                        _id: existing._id
+                        _id: existing._id,
+                        workflowLocale: value.doc.workflowLocale
                       });
                     } else {
                       await collections.insertOne({
                         ...value.doc,
-                        workflowLocale: value.doc.workflowLocale,
-                        _id: self.apos.utils.generateId()
+                        _id: self.apos.utils.generateId(),
+                        workflowLocale: value.doc.workflowLocale
                       });
                     }
                   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apostrophecms/sync-content",
-  "version": "1.0.0-alpha",
+  "version": "1.0.0-alpha.2",
   "description": "Content sync utility for ApostropheCMS sites",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

See changelog entry

## What are the specific steps to test this change?

You could sync one locale with `--workflow-locale`, but I have tested it thoroughly.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
